### PR TITLE
use getFragmentManager() instead of getChildFragmentManager()

### DIFF
--- a/library/src/main/java/jp/seesaa/android/library/dialog/AbstractBuilder.java
+++ b/library/src/main/java/jp/seesaa/android/library/dialog/AbstractBuilder.java
@@ -210,7 +210,7 @@ public abstract class AbstractBuilder<T extends AbstractBuilder<T, F>, F extends
 
         FragmentManager fm;
         if (parentFragment != null) {
-            fm = parentFragment.getChildFragmentManager();
+            fm = parentFragment.getFragmentManager();
         } else {
             fm = activity.getSupportFragmentManager();
         }


### PR DESCRIPTION
crash this library on API level >= 26 devices.
I referred to [this issue](https://github.com/Kunzisoft/AndroidClearChroma/issues/9).